### PR TITLE
using TMUX_BIN

### DIFF
--- a/power-zoom.tmux
+++ b/power-zoom.tmux
@@ -5,7 +5,7 @@
 #
 #   Part of https://github.com/jaclu/tmux-power-zoom
 #
-#   Version: 0.2.0 2022-04-15
+#   Version: 0.2.1 2022-09-15
 #
 
 # shellcheck disable=SC1007
@@ -68,16 +68,16 @@ log_it "use_notes=[$use_notes]"
 if [ "$without_prefix" -eq 1 ]; then
     if [ "$use_notes" -eq 1 ]; then
         #  shellcheck disable=SC2154
-        tmux bind -N "$plugin_name" -n "$trigger_key" run-shell "$SCRIPTS_DIR"/power_zoom.sh
+        $TMUX_BIN bind -N "$plugin_name" -n "$trigger_key" run-shell "$SCRIPTS_DIR"/power_zoom.sh
     else
-        tmux bind -n "$trigger_key" run-shell "$SCRIPTS_DIR"/power_zoom.sh
+        $TMUX_BIN bind -n "$trigger_key" run-shell "$SCRIPTS_DIR"/power_zoom.sh
     fi
     log_it "Menus bound to: $trigger_key"
 else
     if [ "$use_notes" -eq 1 ]; then
-        tmux bind -N "$plugin_name" "$trigger_key" run-shell "$SCRIPTS_DIR"/power_zoom.sh
+        $TMUX_BIN bind -N "$plugin_name" "$trigger_key" run-shell "$SCRIPTS_DIR"/power_zoom.sh
     else
-        tmux bind "$trigger_key" run-shell "$SCRIPTS_DIR"/power_zoom.sh
+        $TMUX_BIN bind "$trigger_key" run-shell "$SCRIPTS_DIR"/power_zoom.sh
     fi
     log_it "Menus bound to: <prefix> $trigger_key"
 fi
@@ -88,5 +88,5 @@ if [ "$mouse_zoom" -eq 1 ]; then
     #  First select the mouse-over pane, then trigger zoom, otherwise the
     #  focused pane would get zoomed, and not the clicked one.
     #
-    tmux bind -n DoubleClick3Pane "select-pane -t= ; run-shell -t= \"$SCRIPTS_DIR/power_zoom.sh\""
+    $TMUX_BIN bind -n DoubleClick3Pane "select-pane -t= ; run-shell -t= \"$SCRIPTS_DIR/power_zoom.sh\""
 fi

--- a/scripts/power_zoom.sh
+++ b/scripts/power_zoom.sh
@@ -5,7 +5,7 @@
 #
 #   Part of https://github.com/jaclu/tmux-power-zoom
 #
-#   Version: 0.1.3 2022-04-13
+#   Version: 0.1.4 2022-09-15
 #
 #   Tracking the placeholder pane by its pane title, this works regardless
 #   if pane titles are displayed or not.
@@ -22,14 +22,14 @@ power_zoom() {
     recursion="$1"
     [ "$recursion" != "" ] && log_it "power_zoom($recursion) triggered"
 
-    primary_pane_id="$(tmux display -p '#D')"
-    primary_pane_title="$(tmux display -p '#T')"
+    primary_pane_id="$($TMUX_BIN display -p '#D')"
+    primary_pane_title="$($TMUX_BIN display -p '#T')"
 
     placeholder_stub="=== POWER ZOOM === place-holder for pane:"
     placeholder_title="$placeholder_stub $primary_pane_id"
 
     log_it "Checking for this place-holder: [$placeholder_title]"
-    placeholder_pane=$(tmux list-panes -a -F "#D #T" | grep "$placeholder_title" | awk '{ print $1 }')
+    placeholder_pane=$($TMUX_BIN list-panes -a -F "#D #T" | grep "$placeholder_title" | awk '{ print $1 }')
 
     if [ -n "$placeholder_pane" ]; then
         #
@@ -37,17 +37,17 @@ power_zoom() {
         #  the place-holder
         #
         log_it "Found a matching place-holder, move this pane there and delete place-holder"
-        tmux join-pane -b -t "$placeholder_pane"
-        tmux kill-pane -t "$placeholder_pane"
+        $TMUX_BIN join-pane -b -t "$placeholder_pane"
+        $TMUX_BIN kill-pane -t "$placeholder_pane"
     else
         #
         #  Zoom this to new window
         #
-        if [ "$(tmux list-panes | wc -l)" -eq 1 ]; then
+        if [ "$($TMUX_BIN list-panes | wc -l)" -eq 1 ]; then
              error_msg "Can't zoom only pane in a window"
             return 0
         fi
-        if [ "$(tmux display -p '#T' | grep "$placeholder_stub")" != "" ]; then
+        if [ "$($TMUX_BIN display -p '#T' | grep "$placeholder_stub")" != "" ]; then
             #  shellcheck disable=SC2154
             log_it "This is a $plugin_name place-holder!"
             #
@@ -57,14 +57,14 @@ power_zoom() {
                 error_msg "power_zoom is entering repeated recursion, aborting"
                 return 0
             fi
-            pane_id="$(tmux display -p '#T'| awk '{print $8}')"
+            pane_id="$($TMUX_BIN display -p '#T'| awk '{print $8}')"
             log_it "pane_id: [$pane_id]"
-            if ! tmux select-window -t "$pane_id"; then
+            if ! $TMUX_BIN select-window -t "$pane_id"; then
                 error_msg "Failed to find window with Zoomed pane: $pane_id"
                 return 0
             fi
 
-            if ! tmux select-pane -t  "$pane_id"; then
+            if ! $TMUX_BIN select-pane -t  "$pane_id"; then
                 error_msg "Failed to find Zoomed pane: $pane_id"
                 return 0
             fi
@@ -78,11 +78,11 @@ power_zoom() {
         #  is killed and the place-holder is left hanging.
         #
         log_it "Zoom active pane to new window"
-        tmux split-window -b "echo; echo \"  $placeholder_title\"; while true ; do sleep 30; done"
-        tmux select-pane -T "$placeholder_title"
-        tmux select-pane -t "$primary_pane_id"
-        tmux break-pane  # move it to new window
-        tmux rename-window "**POWER ZOOM** $primary_pane_title ($primary_pane_id)"
+        $TMUX_BIN split-window -b "echo; echo \"  $placeholder_title\"; while true ; do sleep 30; done"
+        $TMUX_BIN select-pane -T "$placeholder_title"
+        $TMUX_BIN select-pane -t "$primary_pane_id"
+        $TMUX_BIN break-pane  # move it to new window
+        $TMUX_BIN rename-window "**POWER ZOOM** $primary_pane_title ($primary_pane_id)"
     fi
     return 0
 }

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -5,7 +5,7 @@
 #
 #   Part of https://github.com/jaclu/tmux-power-zoom
 #
-#   Version: 0.2.0 2022-04-15
+#   Version: 0.2.1 2022-09-15
 #
 #  Common stuff
 #
@@ -19,6 +19,17 @@
 #  locations, easily getting out of sync.
 #
 plugin_name="tmux-power-zoom"
+
+
+#
+#  I use an env var TMUX_BIN to point at the current tmux, defined in my
+#  tmux.conf, in order to pick the version matching the server running.
+#  This is needed when checking backwards compatability with various versions.
+#  If not found, it is set to whatever is in path, so should have no negative
+#  impact. In all calls to tmux I use $TMUX_BIN instead in the rest of this
+#  plugin.
+#
+[ -z "$TMUX_BIN" ] && TMUX_BIN="tmux"
 
 
 #
@@ -48,7 +59,7 @@ error_msg() {
     exit_code="${2:-0}"
 
     log_it "$msg"
-    tmux display-message "$plugin_name $msg"
+    $TMUX_BIN display-message "$plugin_name $msg"
     [ "$exit_code" -ne 0 ] && exit "$exit_code"
 }
 
@@ -89,7 +100,7 @@ bool_param() {
 get_tmux_option() {
     gto_option=$1
     gto_default_value=$2
-    gto_value=$(tmux show-option -gqv "$gto_option")
+    gto_value=$($TMUX_BIN show-option -gqv "$gto_option")
     if [ -z "$gto_value" ]; then
         echo "$gto_default_value"
     else


### PR DESCRIPTION
In order to be able to test various versions of tmux for compatibility with plugins, I used ASDF.
This has the drawback of using ~/.asdf/shims/tmux thus not allowing the path to tmux itself to identify what tmux to run, so I have set up my tmux.conf to identify the actual tmux in that case. When using ASDF the actual path to tmux (example: ~/.asdf/installs/tmux/2.8/bin/tmux) is identified and stored in the env variable TMUX_BIN

Using $TMUX_BIN whenever the plugin needs to access tmux from the shell, ensures that the plugin uses the tmux associated with the running session. This makes my testing much more convenient since I don't have to kill my main tmux each time I want to test a specific version, I just run a separate tmux under the version being tested.
This should not have any impact if TMUX_BIN is not used, since then it defaults to just being 'tmux'